### PR TITLE
Make `prod.sh` use `trunk build --release`

### DIFF
--- a/prod.sh
+++ b/prod.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 pushd frontend
-trunk build --public-url /assets/
+trunk build --release --public-url /assets/
 popd
 
 pushd server


### PR DESCRIPTION
I just did this [in my own project](https://github.com/rozbb/readtomyshoe) and my wasm file dropped 80% in size. Of course build times are slightly longer, but this is `prod.sh`, so it's appropriate.

Thanks for making this template!